### PR TITLE
Correct parsing of allowed hosts

### DIFF
--- a/Crystite/Configuration/ResoniteHeadlessConfig.cs
+++ b/Crystite/Configuration/ResoniteHeadlessConfig.cs
@@ -45,7 +45,7 @@ public record ResoniteHeadlessConfig
     string? DataFolder = null,
     string? CacheFolder = null,
     string? LogsFolder = null,
-    IReadOnlyList<Uri>? AllowedUrlHosts = null,
+    IReadOnlyList<string>? AllowedUrlHosts = null,
     IReadOnlyList<Uri>? AutoSpawnItems = null,
     IReadOnlyList<string>? PluginAssemblies = null,
     bool? GeneratePreCache = null,


### PR DESCRIPTION
This PR properly parses and adds configured hosts to the engine's TemporarilyAllowed list. Entries are first parsed as a URI. If successful, the host and port is used. If not, the entry is split on a colon, then taken as a host and port. This mimics stock headless behavior.

Additionally, a warning is displayed if "localhost" or a local IP is added to the list, as this would expose the server's HTTP API.

Other points worth considering:
- This adds hosts to the ephemeral "temporarily allowed" list. Since there's only methods for adding HTTP and Websocket rules, the headless can't use OSC components.
- For HTTP requests, the game engine doesn't include the port while checking for host access. This is why there is a warning when allowing access to localhost.
- To mimic headless behavior, the configuration parameter is an all or nothing. In the future, it may be desirable to implement a custom configuration field that allows for fine-grained control over the host, port, and scope of protocols.
- - Alternatively, these details could be infered if fully-qualified URI's are used.
- - However, this would require using HostAccessSettings, which is part of the engine's settings system, making it more complex to implement.