### PR TITLE
Allow custom join verifiers to be used

### DIFF
--- a/Crystite/Configuration/WorldStartupParameters.cs
+++ b/Crystite/Configuration/WorldStartupParameters.cs
@@ -22,6 +22,7 @@ namespace Crystite.Configuration;
 /// <param name="Description">An optional description of this session, displayed within the world/session browser.</param>
 /// <param name="MaxUsers">The maximum number of users, allowed to join this session.</param>
 /// <param name="AccessLevel">The access level for this session. Please see <see cref="SessionAccessLevel"/> for more information.</param>
+/// <param name="UseCustomJoinVerifier">When set to true, the VerifyJoinRequest ProtoFlux Node will be used in place of default session access rules.</param>
 /// <param name="HideFromPublicListing">Determines if this session should be hidden from the world/session browser or not.</param>
 /// <param name="Tags">A list of tags, to assist with searching or discovering sessions.</param>
 /// <param name="MobileFriendly">Determines if this session is friendly for mobile/quest users.</param>
@@ -59,6 +60,7 @@ public record WorldStartupParameters
     int MaxUsers = 32,
     [property: JsonConverter(typeof(JsonStringEnumConverter))]
     SessionAccessLevel AccessLevel = SessionAccessLevel.Private,
+    bool UseCustomJoinVerifier = false,
     bool? HideFromPublicListing = null,
     IReadOnlyList<string>? Tags = null,
     bool MobileFriendly = false,

--- a/Crystite/Extensions/WorldExtensions.cs
+++ b/Crystite/Extensions/WorldExtensions.cs
@@ -39,6 +39,7 @@ public static class WorldExtensions
         }
 
         world.AccessLevel = startupParameters.AccessLevel;
+        world.UseCustomJoinVerifier = startupParameters.UseCustomJoinVerifier;
         world.HideFromListing = startupParameters.HideFromPublicListing is true;
         world.MaxUsers = startupParameters.MaxUsers;
         world.MobileFriendly = startupParameters.MobileFriendly;

--- a/Crystite/Services/WorldService.cs
+++ b/Crystite/Services/WorldService.cs
@@ -338,6 +338,7 @@ public class WorldService
                         Description = world.Description,
                         MaxUsers = world.MaxUsers,
                         AccessLevel = world.AccessLevel,
+                        UseCustomJoinVerifier = world.UseCustomJoinVerifier,
                         HideFromPublicListing = world.HideFromListing,
                         Tags = world.Tags.ToList(),
                         MobileFriendly = world.MobileFriendly,


### PR DESCRIPTION
This PR adds the `useCustomJoinVerifier` configuration field and maps it to the world config parameter.