### PR TITLE
Replace references to NeosVR with Resonite

### DIFF
--- a/Crystite/Configuration/ResoniteHeadlessConfig.cs
+++ b/Crystite/Configuration/ResoniteHeadlessConfig.cs
@@ -14,7 +14,7 @@ namespace Crystite.Configuration;
 /// <remarks>
 /// The base schema has been extended with some more properties, enabling further configuration.
 /// </remarks>
-/// <a href="https://raw.githubusercontent.com/Neos-Metaverse/JSONSchemas/main/schemas/NeosHeadlessConfig.schema.json"/>
+/// <a href="https://raw.githubusercontent.com/Yellow-Dog-Man/JSONSchemas/main/schemas/HeadlessConfig.schema.json"/>
 /// <param name="Comment">An optional free form comment for this file. Used for identification for your configuration.</param>
 /// <param name="UniverseID">Optionally, specifies which universe this Headless Server will be in. See our wiki article on Universes for more info.</param>
 /// <param name="TickRate">Configures how many ticks(updates), should occur per second. Default is 60.</param>
@@ -59,7 +59,7 @@ public record ResoniteHeadlessConfig
     [JsonInclude]
     public static Uri Schema => new
     (
-        "https://raw.githubusercontent.com/Neos-Metaverse/JSONSchemas/main/schemas/NeosHeadlessConfig.schema.json"
+        "https://raw.githubusercontent.com/Yellow-Dog-Man/JSONSchemas/main/schemas/HeadlessConfig.schema.json"
     );
 
     /// <summary>

--- a/Crystite/Configuration/WorldStartupParameters.cs
+++ b/Crystite/Configuration/WorldStartupParameters.cs
@@ -15,7 +15,7 @@ namespace Crystite.Configuration;
 /// <remarks>
 /// The base schema has been extended with some more properties, enabling further configuration.
 /// </remarks>
-/// <a href="https://raw.githubusercontent.com/Neos-Metaverse/JSONSchemas/main/schemas/NeosHeadlessConfig.schema.json"/>
+/// <a href="https://raw.githubusercontent.com/Yellow-Dog-Man/JSONSchemas/main/schemas/HeadlessConfig.schema.json"/>
 /// <param name="IsEnabled">When set to false, this will disable this world entry from starting.</param>
 /// <param name="SessionName">The name of the session as shown in the World/Session Browser.</param>
 /// <param name="CustomSessionID">An optional custom session id for this session.</param>

--- a/Crystite/README.md
+++ b/Crystite/README.md
@@ -257,9 +257,9 @@ information.
 normal headless mods. Compatibility is not guaranteed, however, depending on 
 what the mods do - as always, use with caution and your mileage may vary.
 
-To install NML, follow their guide but replace step 3 (where you add the 
+To install RML, follow their guide but replace step 3 (where you add the 
 command-line argument) with an appropriate modification to `appsettings.json`'s
-`pluginAssemblies` property. Add the full path to the NML assembly there.
+`pluginAssemblies` property. Add the full path to the RML assembly there.
 
 There are some use cases that are affected by the security hardening options in 
 use by the systemd service. Primarily, you cannot store mod files outside of 
@@ -370,11 +370,11 @@ It contains a bit of a dive into some internals and has a couple of explanations
 that could be useful for future work with Resonite and headless servers.
 
 
-[1]: https://raw.githubusercontent.com/Neos-Metaverse/JSONSchemas/main/schemas/NeosHeadlessConfig.schema.json
+[1]: https://raw.githubusercontent.com/Yellow-Dog-Man/JSONSchemas/main/schemas/HeadlessConfig.schema.json
 [2]: https://learn.microsoft.com/en-us/dotnet/core/extensions/logging#configure-logging
 [3]: https://github.com/serilog/serilog-settings-configuration
 [4]: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options
 [5]: docs/index.md
 [6]: docs/nitty-gritty.md
-[7]: https://github.com/neos-modding-group/NeosModLoader
+[7]: https://github.com/resonite-modding-group/ResoniteModLoader
 [8]: https://github.com/dotnet/runtime/issues/36569

--- a/Crystite/appsettings.json
+++ b/Crystite/appsettings.json
@@ -21,7 +21,7 @@
         "maxAssetAge": "07:00:00:00"
     },
     "Resonite": {
-        "$schema": "https://raw.githubusercontent.com/Neos-Metaverse/JSONSchemas/main/schemas/NeosHeadlessConfig.schema.json",
+        "$schema": "https://raw.githubusercontent.com/Yellow-Dog-Man/JSONSchemas/main/schemas/HeadlessConfig.schema.json",
         "dataFolder": "/var/lib/crystite/data",
         "cacheFolder": "/var/lib/crystite/data",
         "startWorlds": [

--- a/docs/routes/worlds.md
+++ b/docs/routes/worlds.md
@@ -1,10 +1,10 @@
 # Worlds
-Contains routes and objects for interacting with NeosVR worlds, such as loading,
+Contains routes and objects for interacting with Resonite worlds, such as loading,
 focusing, saving, closing or modifying them.
 
 ## Objects
 ### RestWorld
-A subset of fields from Neos's `World` object.
+A subset of fields from Resonite's `World` object.
 
 | Field              | Type                                      | Description                                              |
 |--------------------|-------------------------------------------|----------------------------------------------------------|
@@ -26,7 +26,7 @@ A subset of fields from Neos's `World` object.
 ```
 
 ### RestUser
-A subset of fields from Neos's `User` object.
+A subset of fields from Resonite's `User` object.
 
 | Field      | Type    | Description                              |
 |------------|---------|------------------------------------------|
@@ -55,12 +55,12 @@ An enumeration of session access levels.
 |------------------|-------|
 | Private          | 0     |
 | LAN              | 1     | 
-| Friends          | 2     |
-| FriendsOfFriends | 3     |
+| Contacts         | 2     |
+| ContactsPlus     | 3     |
 | RegisteredUsers  | 4     |
 | Anyone           | 5     |
 
-  > This type is defined by NeosVR in CloudX.Shared.
+  > This type is defined by Resonite in SkyFrost.Base.
 
 ### RestUserRole
 An enumeration of available roles.
@@ -73,7 +73,7 @@ An enumeration of available roles.
 | Guest      | 4      |
 | Spectator  | 5      |
 
-  > NeosVR does not define a true enumeration for this type; the values here
+  > Resonite does not define a true enumeration for this type; the values here
   > have been picked for this mod only.
 
 ## Routes
@@ -132,10 +132,10 @@ A [RestWorld](#restworld) object.
 Starts a new world.
 
 #### Parameters
-| Field    | Type   | Description                               |
-|----------|--------|-------------------------------------------|
-| url      | string | the Neos record URI of the world to start |
-| template | string | the name of a builtin world template      |
+| Field    | Type   | Description                                   |
+|----------|--------|-----------------------------------------------|
+| url      | string | the `resrec` record URI of the world to start |
+| template | string | the name of a builtin world template          |
 
 > `url` and `template` are mutually exclusive.
 


### PR DESCRIPTION
This cleans up and clarifies any remaining references to NeosVR and its conventions.